### PR TITLE
Correct SPDX identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,7 @@
 	"author": "Robert Mustacchi <rm@fingolfin.org>",
 	"engines": { "node": ">= 0.4" },
 	"main": "ctype.js",
-	"licenses": [ {
-		"type": "MIT",
-		"url": "https://github.com/rmustacc/node-ctype/blob/master/LICENSE"
-	} ],
+	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/rmustacc/node-ctype.git"


### PR DESCRIPTION
The `licenses` property has been deprecated. Use the `license` property with an SPDX expression instead.
- https://docs.npmjs.com/files/package.json#license

PS: This fix helps tools that automatically check dependency licenses.